### PR TITLE
Add cli.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ The main functions are also exported from the module, so you can use the `toAST`
 
 Also, since its a wrapper for [mdast-util-from-markdown](https://github.com/syntax-tree/mdast-util-from-markdown), you can pass `extensions` to it in the options, which should work too.
 
+### Direct use
+
+For direct use in the terminal run `cli.ts`:
+
+```bash
+deno run --allow-net https://raw.githubusercontent.com/littletof/terminal_markdown/master/cli.ts -r https://raw.githubusercontent.com/denoland/deno/master/README.md
+```
+
+Or install it with `deno install`
+
+It has three options:
+
+- `-s` for rendering a string directly: `-s "# markdown string"`
+- `-l` for rendering a local file: `-l ./README.md`
+- `-r` for rendering a remote file: `-r https://raw.githubusercontent.com/denoland/deno/master/README.md`
+
 ## Permissions
 
 The module itself requires no permissions to run.

--- a/cli.ts
+++ b/cli.ts
@@ -1,0 +1,27 @@
+import {renderMarkdown} from './mod.ts';
+
+if(!Deno.args) {
+    throw Error('Please provide a path or url to a file or a markdown string');
+} else {
+    if(!Deno.args[0] || !Deno.args[1]) {
+        throw Error("Please provide -l, -r and a path, or -s and a markdown string as arguments");
+    }
+
+    let text;
+    switch(Deno.args[0]) {
+        case '-l':
+            text = Deno.readTextFileSync(Deno.args[1]);
+            break;
+        case '-r':
+            const resp = await fetch(Deno.args[1]);
+            text = await resp.text();
+            break;
+        case '-s':
+            text = Deno.args[1];
+            break;
+        default:
+            throw Error('Only -l, -r and -s is allowed');
+    }
+
+    console.log(renderMarkdown(text));
+}


### PR DESCRIPTION
Closes #1

Add `cli.ts` which is directly runnable or installable with `deno install`.
Support strings, local paths and remote paths.